### PR TITLE
Adding name element to metadata.rb so that it will work correctly with berkshelf

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "traceview"
 maintainer       "AppNeta"
 maintainer_email "jmeickle@appneta.com"
 license          "All rights reserved"


### PR DESCRIPTION
Berkshelf version 3.1.3 requires a name element in the metadata.