### PR TITLE
update to use yum 3.x cookbook

### DIFF
--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -1,14 +1,9 @@
 majorver = node['platform_version'].to_i.to_s
 arch = node['kernel']['machine']
 
-yum_key "RPM-GPG-KEY-tracelytics" do
-    url "https://yum.tracelytics.com/RPM-GPG-KEY-tracelytics"
-    action :add
-end
-
 yum_repository "tracelytics" do
     url "http://yum.tracelytics.com/#{majorver}/#{arch}"
-    key "RPM-GPG-KEY-tracelytics"
-    description "Tracelytics repository"
-    action :add
+    gpgkey 'https://yum.tracelytics.com/RPM-GPG-KEY-tracelytics'
+    description 'Tracelytics repository'
+    action :create
 end


### PR DESCRIPTION
The 3.x cookbook for yum did away with the yum_key resource, simple change to update.